### PR TITLE
rails-ujs compatibility/bug fix for remote_forms.coffee ajax:error

### DIFF
--- a/app/assets/javascripts/closet/remote_forms.coffee
+++ b/app/assets/javascripts/closet/remote_forms.coffee
@@ -1,5 +1,14 @@
-$(document).on 'ajax:error', 'form[data-remote]', (e, xhr, status, error) ->
-  if (status != 'abort' && error != 'abort')
-    e.preventDefault()
-    $(this).replaceWith(xhr.responseText)
-    $(document).trigger('turbolinks:load')
+rails_ujs = typeof Rails # Check If Rails ujs is used if not default to jQuery_ujs
+if (rails_ujs == 'object')
+  $(document).on 'ajax:error', 'form[data-remote]', (e) ->
+    [data, status, xhr] = e.detail
+    if (status != 'abort')
+      e.preventDefault()
+      $(this).replaceWith(xhr.response)
+      $(document).trigger('turbolinks:load')
+else
+  $(document).on 'ajax:error', 'form[data-remote]', (e, xhr, status, error) ->
+    if (status != 'abort' && error != 'abort')
+      e.preventDefault()
+      $(this).replaceWith(xhr.responseText)
+      $(document).trigger('turbolinks:load')


### PR DESCRIPTION
One of the challenges faced was that the ajax:error events wasn't compatible with Rails-ujs approach. This pull request should make closet gem compatible with Rails-ujs and Jquery-ujs.

**Reference:** http://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html#rails-ujs-event-handlers